### PR TITLE
Cleanup + Simplify

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -222,11 +222,18 @@ bool isStateColliding(const bool test_for_self_collision, const planning_scene::
 void normalizeQuaternion(geometry_msgs::Quaternion& quat);
 
 /**
- * @brief Fetches the pose defining a constraint with any offset applied.
+ * @brief Adapt goal pose, defined by position+orientation, to consider offset
  * @param constraint to apply offset to
  * @param offset to apply to the constraint
  * @param orientation to apply to the offset
- * @return
+ * @return final goal pose
  */
-Eigen::Isometry3d getConstraintPose(const moveit_msgs::Constraints& constraint, const geometry_msgs::Vector3& offset,
-                                    const geometry_msgs::Quaternion& orientation);
+Eigen::Isometry3d getConstraintPose(const geometry_msgs::Point& position, const geometry_msgs::Quaternion& orientation,
+                                    const geometry_msgs::Vector3& offset);
+
+/**
+ * @brief Conviencency method, passing args from a goal constraint
+ * @param goal goal constraint
+ * @return final goal pose
+ */
+Eigen::Isometry3d getConstraintPose(const moveit_msgs::Constraints& goal);

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -141,10 +141,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     {
       frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
     }
-    moveit_msgs::Constraints goal = req.goal_constraints.front();
-    geometry_msgs::Vector3 goal_offset = goal.position_constraints.front().target_point_offset;
-    geometry_msgs::Quaternion goal_orientation = goal.orientation_constraints.front().orientation;
-    info.goal_pose = getConstraintPose(goal, goal_offset, goal_orientation);
+    info.goal_pose = getConstraintPose(req.goal_constraints.front());
   }
 
   assert(req.start_state.joint_state.name.size() == req.start_state.joint_state.position.size());
@@ -179,11 +176,12 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
   info.circ_path_point.first = req.path_constraints.name;
   if (!req.goal_constraints.front().position_constraints.empty())
   {
-    moveit_msgs::Constraints goal = req.goal_constraints.front();
-
-    geometry_msgs::Vector3 goal_offset = goal.position_constraints.front().target_point_offset;
-    geometry_msgs::Quaternion goal_orientation = goal.orientation_constraints.front().orientation;
-    info.circ_path_point.second = getConstraintPose(req.path_constraints, goal_offset, goal_orientation).translation();
+    const moveit_msgs::Constraints& goal = req.goal_constraints.front();
+    info.circ_path_point.second =
+        getConstraintPose(
+            req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front().position,
+            goal.orientation_constraints.front().orientation, goal.position_constraints.front().target_point_offset)
+            .translation();
   }
   else
   {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -116,10 +116,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     {
       frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
     }
-    moveit_msgs::Constraints goal = req.goal_constraints.front();
-    geometry_msgs::Vector3 goal_offset = goal.position_constraints.front().target_point_offset;
-    geometry_msgs::Quaternion goal_orientation = goal.orientation_constraints.front().orientation;
-    info.goal_pose = getConstraintPose(goal, goal_offset, goal_orientation);
+    info.goal_pose = getConstraintPose(req.goal_constraints.front());
   }
 
   assert(req.start_state.joint_state.name.size() == req.start_state.joint_state.position.size());

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -237,10 +237,7 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
   // solve the ik
   else
   {
-    moveit_msgs::Constraints goal = req.goal_constraints.front();
-    geometry_msgs::Vector3 goal_offset = goal.position_constraints.front().target_point_offset;
-    geometry_msgs::Quaternion goal_orientation = goal.orientation_constraints.front().orientation;
-    Eigen::Isometry3d goal_pose = getConstraintPose(goal, goal_offset, goal_orientation);
+    Eigen::Isometry3d goal_pose = getConstraintPose(req.goal_constraints.front());
     if (!computePoseIK(scene, req.group_name, req.goal_constraints.at(0).position_constraints.at(0).link_name,
                        goal_pose, robot_model_->getModelFrame(), info.start_joint_position, info.goal_joint_position))
     {


### PR DESCRIPTION
- Use const references where feasible, thus avoiding copying data
- Change API of getConstraintPose to accept pos+orientation + offset
- Convenience method extracting those args from a goal getConstraintPose

Addresses https://github.com/ros-planning/moveit/pull/2890#discussion_r734472121