### PR TITLE
Bugfix/fix lin plans using subframes

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -76,16 +76,16 @@ bool computePoseIK(const planning_scene::PlanningSceneConstPtr& scene, const std
 
 /**
  * @brief compute the pose of a link at give robot state
- * @param scene: planning scene
+ * @param robot_state: an arbitrary robot state (with collision objects attached)
  * @param link_name: target link name
  * @param joint_state: joint positons of this group
  * @param pose: pose of the link in base frame of robot model
  * @return true if succeed
  */
-bool computeLinkFK(const planning_scene::PlanningSceneConstPtr& scene, const std::string& link_name,
+bool computeLinkFK(robot_state::RobotState& robot_state, const std::string& link_name,
                    const std::map<std::string, double>& joint_state, Eigen::Isometry3d& pose);
 
-bool computeLinkFK(const planning_scene::PlanningSceneConstPtr& scene, const std::string& link_name,
+bool computeLinkFK(robot_state::RobotState& robot_state, const std::string& link_name,
                    const std::vector<std::string>& joint_names, const std::vector<double>& joint_positions,
                    Eigen::Isometry3d& pose);
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -76,16 +76,16 @@ bool computePoseIK(const planning_scene::PlanningSceneConstPtr& scene, const std
 
 /**
  * @brief compute the pose of a link at give robot state
- * @param robot_model: kinematic model of the robot
+ * @param scene: planning scene
  * @param link_name: target link name
  * @param joint_state: joint positons of this group
  * @param pose: pose of the link in base frame of robot model
  * @return true if succeed
  */
-bool computeLinkFK(const robot_model::RobotModelConstPtr& robot_model, const std::string& link_name,
+bool computeLinkFK(const planning_scene::PlanningSceneConstPtr& scene, const std::string& link_name,
                    const std::map<std::string, double>& joint_state, Eigen::Isometry3d& pose);
 
-bool computeLinkFK(const robot_model::RobotModelConstPtr& robot_model, const std::string& link_name,
+bool computeLinkFK(const planning_scene::PlanningSceneConstPtr& scene, const std::string& link_name,
                    const std::vector<std::string>& joint_names, const std::vector<double>& joint_positions,
                    Eigen::Isometry3d& pose);
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
@@ -57,6 +57,8 @@ CREATE_MOVEIT_ERROR_CODE_EXCEPTION(UnknownLinkNameOfAuxiliaryPoint, moveit_msgs:
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(NumberOfConstraintsMismatch, moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(CircJointMissingInStartState, moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE);
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(CircInverseForGoalIncalculable, moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(CircForwardForStartIncalculable, moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(CircForwardForGoalIncalculable, moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME);
 
 /**
  * @brief This class implements a trajectory generator of arcs in Cartesian

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
@@ -52,6 +52,8 @@ CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LinTrajectoryConversionFailure, moveit_msgs::
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(JointNumberMismatch, moveit_msgs::MoveItErrorCodes::INVALID_GOAL_CONSTRAINTS);
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LinJointMissingInStartState, moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE);
 CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LinInverseForGoalIncalculable, moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LinForwardForStartIncalculable, moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME);
+CREATE_MOVEIT_ERROR_CODE_EXCEPTION(LinForwardForGoalIncalculable, moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME);
 
 /**
  * @brief This class implements a linear trajectory generator in Cartesian

--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -239,7 +239,8 @@ CommandListManager::solveSequenceItems(const planning_scene::PlanningSceneConstP
     if (res.error_code_.val != res.error_code_.SUCCESS)
     {
       std::ostringstream os;
-      os << "Could not solve request\n---\n" << req << "\n---\n";
+      // os << "Could not solve request\n---\n" << req << "\n---\n";
+      os << "Could not solve request\n";
       throw PlanningPipelineException(os.str(), res.error_code_.val);
     }
     motion_plan_responses.emplace_back(res);

--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -239,7 +239,6 @@ CommandListManager::solveSequenceItems(const planning_scene::PlanningSceneConstP
     if (res.error_code_.val != res.error_code_.SUCCESS)
     {
       std::ostringstream os;
-      // os << "Could not solve request\n---\n" << req << "\n---\n";
       os << "Could not solve request\n";
       throw PlanningPipelineException(os.str(), res.error_code_.val);
     }

--- a/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/move_group_sequence_service.cpp
@@ -41,6 +41,7 @@
 #include "pilz_industrial_motion_planner/capability_names.h"
 #include "pilz_industrial_motion_planner/command_list_manager.h"
 #include "pilz_industrial_motion_planner/trajectory_generation_exceptions.h"
+#include "moveit/planning_scene_interface/planning_scene_interface.h"
 
 namespace pilz_industrial_motion_planner
 {
@@ -117,7 +118,6 @@ bool MoveGroupSequenceService::plan(moveit_msgs::GetMotionSequence::Request& req
   res.response.planning_time = (ros::Time::now() - planning_start).toSec();
   return true;
 }
-
 }  // namespace pilz_industrial_motion_planner
 
 #include <pluginlib/class_list_macros.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -76,10 +76,6 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
   }
 
   moveit::core::RobotState rstate = scene->getCurrentState();
-  
-  // By setting the robot state to default values, we basically allow
-  // the user of this function to supply an incomplete or even empty seed.
-  rstate.setToDefaultValues();
   rstate.setVariablePositions(seed);
 
   moveit::core::GroupStateValidityCallbackFn ik_constraint_function;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -116,27 +116,24 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
                        timeout);
 }
 
-bool pilz_industrial_motion_planner::computeLinkFK(const planning_scene::PlanningSceneConstPtr& scene,
+bool pilz_industrial_motion_planner::computeLinkFK(robot_state::RobotState& robot_state,
                                                    const std::string& link_name,
                                                    const std::map<std::string, double>& joint_state,
-                                                   Eigen::Isometry3d& pose)
-{  // create robot state
-  robot_state::RobotState rstate = scene->getCurrentState();
-
+                                                   Eigen::Isometry3d& pose) {
   // check the reference frame of the target pose
-  if (!rstate.knowsFrameTransform(link_name))
+  if (!robot_state.knowsFrameTransform(link_name))
   {
     ROS_ERROR_STREAM("The target link " << link_name << " is not known by robot.");
     return false;
   }
 
   // set the joint positions
-  rstate.setToDefaultValues();
-  rstate.setVariablePositions(joint_state);
+  robot_state.setToDefaultValues();
+  robot_state.setVariablePositions(joint_state);
 
   // update the frame
-  rstate.update();
-  pose = rstate.getFrameTransform(link_name);
+  robot_state.update();
+  pose = robot_state.getFrameTransform(link_name);
   return true;
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -102,10 +102,10 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
                        timeout);
 }
 
-bool pilz_industrial_motion_planner::computeLinkFK(robot_state::RobotState& robot_state,
-                                                   const std::string& link_name,
+bool pilz_industrial_motion_planner::computeLinkFK(robot_state::RobotState& robot_state, const std::string& link_name,
                                                    const std::map<std::string, double>& joint_state,
-                                                   Eigen::Isometry3d& pose) {
+                                                   Eigen::Isometry3d& pose)
+{
   // check the reference frame of the target pose
   if (!robot_state.knowsFrameTransform(link_name))
   {
@@ -217,7 +217,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
        ++time_iter)
   {
     tf2::fromMsg(tf2::toMsg(trajectory.Pos(*time_iter)), pose_sample);
-    
+
     if (!computePoseIK(scene, group_name, link_name, pose_sample, robot_model->getModelFrame(), ik_solution_last,
                        ik_solution, check_self_collision))
     {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -217,6 +217,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
        ++time_iter)
   {
     tf2::fromMsg(tf2::toMsg(trajectory.Pos(*time_iter)), pose_sample);
+    
     if (!computePoseIK(scene, group_name, link_name, pose_sample, robot_model->getModelFrame(), ik_solution_last,
                        ik_solution, check_self_collision))
     {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -203,12 +203,12 @@ void TrajectoryGenerator::checkCartesianGoalConstraint(const moveit_msgs::Constr
     throw PositionOrientationConstraintNameMismatch(os.str());
   }
 
-  if (!robot_model_->getJointModelGroup(group_name)->canSetStateFromIK(pos_constraint.link_name))
-  {
-    std::ostringstream os;
-    os << "No IK solver available for link: \"" << pos_constraint.link_name << "\"";
-    throw NoIKSolverAvailable(os.str());
-  }
+  // if (!robot_model_->getJointModelGroup(group_name)->canSetStateFromIK(pos_constraint.link_name))
+  // {
+  //   std::ostringstream os;
+  //   os << "No IK solver available for link: \"" << pos_constraint.link_name << "\"";
+  //   throw NoIKSolverAvailable(os.str());
+  // }
 
   if (pos_constraint.constraint_region.primitive_poses.empty())
   {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -125,7 +125,11 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    computeLinkFK(robot_model_, info.link_name, info.goal_joint_position, info.goal_pose);
+    if(!computeLinkFK(scene, info.link_name, info.goal_joint_position, info.goal_pose)) {
+      std::ostringstream os;
+      os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
+      throw CircForwardForGoalIncalculable(os.str());
+    }
   }
   // goal given in Cartesian space
   else
@@ -160,7 +164,11 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  computeLinkFK(robot_model_, info.link_name, info.start_joint_position, info.start_pose);
+  if(!computeLinkFK(scene, info.link_name, info.start_joint_position, info.start_pose)) {
+    std::ostringstream os;
+    os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
+    throw CircForwardForStartIncalculable(os.str());
+  }
 
   // check goal pose ik before Cartesian motion plan starts
   std::map<std::string, double> ik_solution;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -93,6 +93,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
 
   info.group_name = req.group_name;
   std::string frame_id{ robot_model_->getModelFrame() };
+  robot_state::RobotState robot_state = scene->getCurrentState();
 
   // goal given in joint space
   if (!req.goal_constraints.front().joint_constraints.empty())
@@ -125,7 +126,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    if(!computeLinkFK(scene, info.link_name, info.goal_joint_position, info.goal_pose)) {
+    if(!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose)) {
       std::ostringstream os;
       os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
       throw CircForwardForGoalIncalculable(os.str());
@@ -164,7 +165,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  if(!computeLinkFK(scene, info.link_name, info.start_joint_position, info.start_pose)) {
+  if(!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose)) {
     std::ostringstream os;
     os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
     throw CircForwardForStartIncalculable(os.str());

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -126,7 +126,8 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    if(!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose)) {
+    if (!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose))
+    {
       std::ostringstream os;
       os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
       throw CircForwardForGoalIncalculable(os.str());
@@ -165,7 +166,8 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  if(!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose)) {
+  if (!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose))
+  {
     std::ostringstream os;
     os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
     throw CircForwardForStartIncalculable(os.str());

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -97,9 +97,11 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    // Ignored return value because at this point the function should always
-    // return 'true'.
-    computeLinkFK(robot_model_, info.link_name, info.goal_joint_position, info.goal_pose);
+    if(!computeLinkFK(scene, info.link_name, info.goal_joint_position, info.goal_pose)) {
+      std::ostringstream os;
+      os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
+      throw LinForwardForGoalIncalculable(os.str());
+    }
   }
   // goal given in Cartesian space
   else
@@ -134,9 +136,11 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  // Ignored return value because at this point the function should always
-  // return 'true'.
-  computeLinkFK(robot_model_, info.link_name, info.start_joint_position, info.start_pose);
+  if (!computeLinkFK(scene, info.link_name, info.start_joint_position, info.start_pose)) {
+    std::ostringstream os;
+    os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
+    throw LinForwardForStartIncalculable(os.str());
+  }
 
   // check goal pose ik before Cartesian motion plan starts
   std::map<std::string, double> ik_solution;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -98,7 +98,8 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    if(!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose)) {
+    if (!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose))
+    {
       std::ostringstream os;
       os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
       throw LinForwardForGoalIncalculable(os.str());
@@ -137,7 +138,8 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  if (!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose)) {
+  if (!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose))
+  {
     std::ostringstream os;
     os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
     throw LinForwardForStartIncalculable(os.str());

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -70,6 +70,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
 
   info.group_name = req.group_name;
   std::string frame_id{ robot_model_->getModelFrame() };
+  robot_state::RobotState robot_state = scene->getCurrentState();
 
   // goal given in joint space
   if (!req.goal_constraints.front().joint_constraints.empty())
@@ -97,7 +98,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
       info.goal_joint_position[joint_item.joint_name] = joint_item.position;
     }
 
-    if(!computeLinkFK(scene, info.link_name, info.goal_joint_position, info.goal_pose)) {
+    if(!computeLinkFK(robot_state, info.link_name, info.goal_joint_position, info.goal_pose)) {
       std::ostringstream os;
       os << "Failed to compute forward kinematics for link: " << info.link_name << " of goal joints";
       throw LinForwardForGoalIncalculable(os.str());
@@ -136,7 +137,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     info.start_joint_position[joint_name] = req.start_state.joint_state.position[index];
   }
 
-  if (!computeLinkFK(scene, info.link_name, info.start_joint_position, info.start_pose)) {
+  if (!computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose)) {
     std::ostringstream os;
     os << "Failed to compute forward kinematics for link: " << info.link_name << " of start joints";
     throw LinForwardForStartIncalculable(os.str());

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_functions.cpp
@@ -105,6 +105,7 @@ protected:
   // ros stuff
   ros::NodeHandle ph_{ "~" };
   robot_model::RobotModelConstPtr robot_model_{ robot_model_loader::RobotModelLoader(GetParam()).getModel() };
+  robot_state::RobotState robot_state_{ robot_model_ };
   planning_scene::PlanningSceneConstPtr planning_scene_{ new planning_scene::PlanningScene(robot_model_) };
 
   // test parameters from parameter server
@@ -181,27 +182,27 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, TipLinkFK)
 {
   Eigen::Isometry3d tip_pose;
   std::map<std::string, double> test_state = zero_state_;
-  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_model_, group_tip_link_, test_state, tip_pose));
+  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_state_, group_tip_link_, test_state, tip_pose));
   EXPECT_NEAR(tip_pose(0, 3), 0, EPSILON);
   EXPECT_NEAR(tip_pose(1, 3), 0, EPSILON);
   EXPECT_NEAR(tip_pose(2, 3), L0 + L1 + L2 + L3, EPSILON);
 
   test_state[joint_names_.at(1)] = M_PI_2;
-  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_model_, group_tip_link_, test_state, tip_pose));
+  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_state_, group_tip_link_, test_state, tip_pose));
   EXPECT_NEAR(tip_pose(0, 3), L1 + L2 + L3, EPSILON);
   EXPECT_NEAR(tip_pose(1, 3), 0, EPSILON);
   EXPECT_NEAR(tip_pose(2, 3), L0, EPSILON);
 
   test_state[joint_names_.at(1)] = -M_PI_2;
   test_state[joint_names_.at(2)] = M_PI_2;
-  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_model_, group_tip_link_, test_state, tip_pose));
+  EXPECT_TRUE(pilz_industrial_motion_planner::computeLinkFK(robot_state_, group_tip_link_, test_state, tip_pose));
   EXPECT_NEAR(tip_pose(0, 3), -L1, EPSILON);
   EXPECT_NEAR(tip_pose(1, 3), 0, EPSILON);
   EXPECT_NEAR(tip_pose(2, 3), L0 - L2 - L3, EPSILON);
 
   // wrong link name
   std::string link_name = "wrong_link_name";
-  EXPECT_FALSE(pilz_industrial_motion_planner::computeLinkFK(robot_model_, link_name, test_state, tip_pose));
+  EXPECT_FALSE(pilz_industrial_motion_planner::computeLinkFK(robot_state_, link_name, test_state, tip_pose));
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes #3517 by allowing pilz to use subframes in goal constraints.

Updates `computePoseIK()` to build a `RobotState` from the `PlanningScene` rather than the `RobotModel`, so that subframes are taken into account. Also adds some error handling logic around calls to this function as, currently, if the passed `link_name` does not exist, the `start_pose` is set to the identity pose, which leads to a less intuitive IK solver error later on.

Tests still need updating.
